### PR TITLE
add usb mass storage device (flash drive) for pico

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(${PROJECT} PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/CMSIS_5/CMSIS/DAP/Firmware/Source/SWO.c
         ${CMAKE_CURRENT_SOURCE_DIR}/CMSIS_5/CMSIS/DAP/Firmware/Source/SW_DP.c
         ${CMAKE_CURRENT_SOURCE_DIR}/bsp/${FAMILY}/cdc_uart.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/bsp/${FAMILY}/msc_drive.c
         )
 
 # Example include

--- a/bsp/rp2040/msc_drive.c
+++ b/bsp/rp2040/msc_drive.c
@@ -1,0 +1,331 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Vlad Tomoiaga (tvlad1234)
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "bsp/board.h"
+#include "tusb.h"
+
+#include "pico/stdlib.h"
+#include "hardware/flash.h"
+
+#if CFG_TUD_MSC
+
+#define WP_PIN 14
+
+#define FLASH_OFFSET_KB 48
+#define FLASH_TARGET_OFFSET (FLASH_OFFSET_KB * 1024)
+uint8_t *flash_target_contents = (uint8_t *)(XIP_BASE + FLASH_TARGET_OFFSET);
+
+enum
+{
+    // FLASH_DISK_BLOCK_NUM = 490,
+    FLASH_DISK_BLOCK_NUM = ((2048 - FLASH_OFFSET_KB) / 4),
+    FLASH_DISK_BLOCK_SIZE = 4096
+};
+
+#if SERIAL_LOG
+char printBuf[100]; // buffer for printing messages to serial
+#endif
+
+static uint8_t lba_buffer[FLASH_DISK_BLOCK_SIZE]; // buffer to write to
+static uint32_t prevWriteLba = -1;                // last LBA that's been written to
+
+bool read_wp_pin(void)
+{
+    static bool pin_init = false;
+    if (!pin_init)
+    {
+        gpio_init(WP_PIN);
+        gpio_set_dir(WP_PIN, GPIO_IN);
+        gpio_pull_up(WP_PIN);
+        sleep_ms(10);
+        pin_init = true;
+    }
+    return !gpio_get(WP_PIN);
+}
+
+// Update flash
+void update_flash_block(uint32_t block, uint8_t *data)
+{
+
+#if SERIAL_LOG
+    if (tud_cdc_connected())
+    {
+        sprintf(printBuf, "FLASH: updating block %d\n\r", prevWriteLba);
+        tud_cdc_write_str(printBuf);
+    }
+#endif
+
+    // write the previous block to flash
+    uint32_t ints = save_and_disable_interrupts();                                  // disable interrupts (needed if running from flash)
+    flash_range_erase(FLASH_TARGET_OFFSET + (FLASH_DISK_BLOCK_SIZE * block), 4096); // need to erase first
+    flash_range_program(FLASH_TARGET_OFFSET + (FLASH_DISK_BLOCK_SIZE * block), data, FLASH_DISK_BLOCK_SIZE);
+    restore_interrupts(ints); // restore interrupts
+}
+
+// Invoked to determine max LUN
+uint8_t tud_msc_get_maxlun_cb(void)
+{
+    return 1; // we only have 1 LUN
+}
+
+// Invoked when received SCSI_CMD_INQUIRY
+// Application fill vendor id, product id and revision with string up to 8, 16, 4 characters respectively
+void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4])
+{
+    char vid[] = "TinyUSB";
+    char pid[] = "Mass Storage";
+    char rev[] = "1.0";
+
+    memcpy(vendor_id, vid, strlen(vid));
+    memcpy(product_id, pid, strlen(pid));
+    memcpy(product_rev, rev, strlen(rev));
+}
+
+// Invoked when received Test Unit Ready command.
+// return true allowing host to read/write this LUN e.g SD card inserted
+bool tud_msc_test_unit_ready_cb(uint8_t lun)
+{
+    (void)lun;
+
+    return true; // always ready
+}
+
+// Invoked when received SCSI_CMD_READ_CAPACITY_10 and SCSI_CMD_READ_FORMAT_CAPACITY to determine the disk size
+// Application update block count and block size
+void tud_msc_capacity_cb(uint8_t lun, uint32_t *block_count, uint16_t *block_size)
+{
+    switch (lun)
+    {
+    case 0: // Flash
+        *block_count = FLASH_DISK_BLOCK_NUM;
+        *block_size = FLASH_DISK_BLOCK_SIZE;
+        break;
+
+    default:
+        *block_count = 0;
+        *block_count = 0;
+        break;
+    }
+}
+
+// Invoked when received Start Stop Unit command
+// - Start = 0 : stopped power mode, if load_eject = 1 : unload disk storage
+// - Start = 1 : active mode, if load_eject = 1 : load disk storage
+bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject)
+{
+    (void)power_condition;
+
+    if (load_eject)
+    {
+        if (start)
+        {
+            // load disk storage
+        }
+        else
+        {
+            // unload disk storage
+        }
+    }
+
+    return true;
+}
+
+// Callback invoked when received READ10 command.
+// Copy disk's data to buffer (up to bufsize) and return number of copied bytes.
+int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void *buffer, uint32_t bufsize)
+{
+
+#if SERIAL_LOG
+    if (tud_cdc_connected())
+    {
+        sprintf(printBuf, "LUN%d: read %d bytes from block %d, offset %d, ", lun, bufsize, lba, offset);
+        tud_cdc_write_str(printBuf);
+        if (lba == prevWriteLba)
+            sprintf(printBuf, "from buffer\n\r");
+        else
+            sprintf(printBuf, "from flash\n\r");
+        tud_cdc_write_str(printBuf);
+    }
+#endif
+
+    // out of disk
+    switch (lun)
+    {
+    case 0:
+        if (lba >= FLASH_DISK_BLOCK_NUM)
+            return -1;
+        break;
+
+    default:
+        return -1;
+        break;
+    }
+
+    uint8_t const *addr;
+    switch (lun)
+    {
+    case 0:
+        if (lba == prevWriteLba)
+            addr = lba_buffer + offset;
+        else
+            addr = flash_target_contents + (FLASH_DISK_BLOCK_SIZE * lba) + offset;
+        break;
+
+    default:
+        return -1;
+        break;
+    }
+
+    memcpy(buffer, addr, bufsize);
+    return bufsize;
+}
+
+bool tud_msc_is_writable_cb(uint8_t lun)
+{
+    (void)lun;
+    return read_wp_pin(); // we can write to all LUNs
+}
+
+// Callback invoked when received WRITE10 command.
+// Process data in buffer to disk's storage and return number of written bytes
+int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t *buffer, uint32_t bufsize)
+{
+
+#if SERIAL_LOG
+    if (tud_cdc_connected())
+    {
+        sprintf(printBuf, "LUN%d: write %d bytes to block %d, offset %d\n\r", lun, bufsize, lba, offset);
+        tud_cdc_write_str(printBuf);
+    }
+#endif
+
+    // out of disk
+    switch (lun)
+    {
+    case 0:
+        if (lba >= FLASH_DISK_BLOCK_NUM)
+            return -1;
+        break;
+
+    default:
+        return -1;
+        break;
+    }
+
+    uint8_t *addr;
+    switch (lun)
+    {
+    case 0: // Flash
+        addr = flash_target_contents + (FLASH_DISK_BLOCK_SIZE * lba);
+
+        if (lba != prevWriteLba) // flush the buffer to the flash if we're moving to another LBA
+            update_flash_block(prevWriteLba, lba_buffer);
+
+        // write to the buffer
+        memcpy(lba_buffer + offset, buffer, bufsize);
+        prevWriteLba = lba;
+        break;
+
+    default:
+        return -1;
+        break;
+    }
+
+    return bufsize;
+}
+
+// Callback invoked when received an SCSI command not in built-in list below
+// - READ_CAPACITY10, READ_FORMAT_CAPACITY, INQUIRY, MODE_SENSE6, REQUEST_SENSE
+// - READ10 and WRITE10 has their own callbacks
+int32_t tud_msc_scsi_cb(uint8_t lun, uint8_t const scsi_cmd[16], void *buffer, uint16_t bufsize)
+{
+    // read10 & write10 has their own callback and MUST not be handled here
+
+    void const *response = NULL;
+    int32_t resplen = 0;
+
+    // most scsi handled is input
+    bool in_xfer = true;
+
+    switch (scsi_cmd[0])
+    {
+    case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
+        // Host is about to read/write etc ... better not to disconnect disk
+
+#if SERIAL_LOG
+        if (tud_cdc_connected())
+        {
+            sprintf(printBuf, "Ejected LUN %d\n\r", lun);
+            tud_cdc_write_str(printBuf);
+        }
+#endif
+
+        if (lun == 0 && prevWriteLba > -1) // Flush buffer to flash on eject
+            update_flash_block(prevWriteLba, lba_buffer);
+
+        resplen = 0;
+        break;
+
+    case SCSI_CMD_START_STOP_UNIT:
+        // Host try to eject/safe remove/poweroff us. We could safely disconnect with disk storage, or go into lower power
+        // scsi_start_stop_unit_t const * start_stop = (scsi_start_stop_unit_t const *) scsi_cmd;
+        // Start bit = 0 : low power mode, if load_eject = 1 : unmount disk storage as well
+        // Start bit = 1 : Ready mode, if load_eject = 1 : mount disk storage
+        //  start_stop->start;
+        //  start_stop->load_eject;
+
+        resplen = 0;
+        break;
+
+    default:
+        // Set Sense = Invalid Command Operation
+        tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);
+
+        // negative means error -> tinyusb could stall and/or response with failed status
+        resplen = -1;
+        break;
+    }
+
+    // return resplen must not larger than bufsize
+    if (resplen > bufsize)
+        resplen = bufsize;
+
+    if (response && (resplen > 0))
+    {
+        if (in_xfer)
+        {
+            memcpy(buffer, response, resplen);
+        }
+        else
+        {
+            // SCSI output
+        }
+    }
+
+    return resplen;
+}
+
+#endif

--- a/tusb_config.h
+++ b/tusb_config.h
@@ -96,7 +96,7 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC               1
-#define CFG_TUD_MSC               0
+#define CFG_TUD_MSC               1
 #define CFG_TUD_HID               1
 #define CFG_TUD_MIDI              0
 #define CFG_TUD_VENDOR            0
@@ -107,6 +107,9 @@
 // CDC FIFO size of TX and RX
 #define CFG_TUD_CDC_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
 #define CFG_TUD_CDC_TX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+
+// MSC Buffer size of Device Mass storage
+#define CFG_TUD_MSC_EP_BUFSIZE    512
 
 #ifdef __cplusplus
  }

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
@@ -32,9 +32,9 @@
  * Auto ProductID layout's Bitmap:
  *   [MSB]         HID | MSC | CDC          [LSB]
  */
-#define _PID_MAP(itf, n)  ( (CFG_TUD_##itf) << (n) )
-#define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
-                           _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
+#define _PID_MAP(itf, n) ((CFG_TUD_##itf) << (n))
+#define USB_PID (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
+                 _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4))
 
 // String Descriptor Index
 enum
@@ -49,31 +49,30 @@ enum
 // Device Descriptors
 //--------------------------------------------------------------------+
 tusb_desc_device_t const desc_device =
-{
-    .bLength            = sizeof(tusb_desc_device_t),
-    .bDescriptorType    = TUSB_DESC_DEVICE,
-    .bcdUSB             = 0x0200,
-    .bDeviceClass       = 0x00,
-    .bDeviceSubClass    = 0x00,
-    .bDeviceProtocol    = 0x00,
-    .bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
+    {
+        .bLength = sizeof(tusb_desc_device_t),
+        .bDescriptorType = TUSB_DESC_DEVICE,
+        .bcdUSB = 0x0200,
+        .bDeviceClass = 0x00,
+        .bDeviceSubClass = 0x00,
+        .bDeviceProtocol = 0x00,
+        .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
 
-    .idVendor           = 0xCafe,
-    .idProduct          = USB_PID,
-    .bcdDevice          = 0x0102,
+        .idVendor = 0xCafe,
+        .idProduct = USB_PID,
+        .bcdDevice = 0x0102,
 
-    .iManufacturer      = STRID_MANUFACTURER,
-    .iProduct           = STRID_PRODUCT,
-    .iSerialNumber      = STRID_SERIAL,
+        .iManufacturer = STRID_MANUFACTURER,
+        .iProduct = STRID_PRODUCT,
+        .iSerialNumber = STRID_SERIAL,
 
-    .bNumConfigurations = 0x01
-};
+        .bNumConfigurations = 0x01};
 
 // Invoked when received GET DEVICE DESCRIPTOR
 // Application return pointer to descriptor
-uint8_t const * tud_descriptor_device_cb(void)
+uint8_t const *tud_descriptor_device_cb(void)
 {
-  return (uint8_t const *) &desc_device;
+  return (uint8_t const *)&desc_device;
 }
 
 //--------------------------------------------------------------------+
@@ -81,16 +80,15 @@ uint8_t const * tud_descriptor_device_cb(void)
 //--------------------------------------------------------------------+
 
 static uint8_t const desc_hid_report[] =
-{
-  TUD_HID_REPORT_DESC_GENERIC_INOUT(CFG_TUD_HID_EP_BUFSIZE)
-};
+    {
+        TUD_HID_REPORT_DESC_GENERIC_INOUT(CFG_TUD_HID_EP_BUFSIZE)};
 
 // Invoked when received GET HID REPORT DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
-uint8_t const * tud_hid_descriptor_report_cb(uint8_t itf)
+uint8_t const *tud_hid_descriptor_report_cb(uint8_t itf)
 {
-  (void) itf;
+  (void)itf;
   return desc_hid_report;
 }
 
@@ -101,36 +99,60 @@ uint8_t const * tud_hid_descriptor_report_cb(uint8_t itf)
 enum
 {
   ITF_NUM_HID,
+#if CFG_TUD_MSC
+  ITF_NUM_MSC,
+#endif
   ITF_NUM_CDC_COM,
   ITF_NUM_CDC_DATA,
   ITF_NUM_TOTAL
 };
 
-#define  CONFIG_TOTAL_LEN  (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_HID_INOUT_DESC_LEN)
+#if CFG_TUD_MSC
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_HID_INOUT_DESC_LEN + TUD_MSC_DESC_LEN)
+#else 
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_HID_INOUT_DESC_LEN)
+#endif
 
-#define EPNUM_HID       0x01
+
+#define EPNUM_HID 0x01
+
+#if CFG_TUD_MSC
+#define EPNUM_MSC_OUT 0x02
+#define EPNUM_MSC_IN 0x82
+
+#define EPNUM_CDC_NOTIF 0x84
+#define EPNUM_CDC_OUT 0x03
+#define EPNUM_CDC_IN 0x83
+
+#else
 #define EPNUM_CDC_NOTIF 0x83
-#define EPNUM_CDC_OUT   0x02
-#define EPNUM_CDC_IN    0x82
+#define EPNUM_CDC_OUT 0x02
+#define EPNUM_CDC_IN 0x82
+#endif
 
 uint8_t const desc_configuration[] =
-{
-  // Config number, interface count, string index, total length, attribute, power in mA
-  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    {
+        // Config number, interface count, string index, total length, attribute, power in mA
+        TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
 
-  // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
-  TUD_HID_INOUT_DESCRIPTOR(ITF_NUM_HID, 0, HID_ITF_PROTOCOL_NONE, sizeof(desc_hid_report), EPNUM_HID, 0x80 | EPNUM_HID, CFG_TUD_HID_EP_BUFSIZE, 1),
+        // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
+        TUD_HID_INOUT_DESCRIPTOR(ITF_NUM_HID, 0, HID_ITF_PROTOCOL_NONE, sizeof(desc_hid_report), EPNUM_HID, 0x80 | EPNUM_HID, CFG_TUD_HID_EP_BUFSIZE, 1),
 
-  // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_COM, 0, EPNUM_CDC_NOTIF, 64, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
+#if CFG_TUD_MSC
+        // Interface number, string index, EP Out & EP In address, EP size
+        TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 0, EPNUM_MSC_OUT, EPNUM_MSC_IN, 64),
+#endif
+
+        // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+        TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_COM, 0, EPNUM_CDC_NOTIF, 64, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
 };
 
 // Invoked when received GET CONFIGURATION DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
-uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
+uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
 {
-  (void) index; // for multiple configurations
+  (void)index; // for multiple configurations
   return desc_configuration;
 }
 
@@ -139,19 +161,19 @@ uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
 //--------------------------------------------------------------------+
 
 // array of pointer to string descriptors
-char const* string_desc_arr [] =
-{
-  [STRID_LANGID]       = (const char[]) { 0x09, 0x04 }, // supported language is English (0x0409)
-  [STRID_MANUFACTURER] = "TinyUSB",                     // Manufacturer
-  [STRID_PRODUCT]      = PRODUCT_PREFIX "CMSIS-DAP",    // Product
+char const *string_desc_arr[] =
+    {
+        [STRID_LANGID] = (const char[]){0x09, 0x04},  // supported language is English (0x0409)
+        [STRID_MANUFACTURER] = "TinyUSB",             // Manufacturer
+        [STRID_PRODUCT] = PRODUCT_PREFIX "CMSIS-DAP", // Product
 };
 static uint16_t _desc_str[32];
 
 // Invoked when received GET STRING DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
-uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
+uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 {
-  (void) langid;
+  (void)langid;
 
   uint8_t chr_count = 0;
 
@@ -159,30 +181,33 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
   {
     memcpy(&_desc_str[1], string_desc_arr[STRID_LANGID], 2);
     chr_count = 1;
-  } else if (STRID_SERIAL == index)
+  }
+  else if (STRID_SERIAL == index)
   {
     chr_count = get_unique_id(_desc_str + 1);
-  } else
+  }
+  else
   {
     // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
     // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
 
-    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return NULL;
+    if (!(index < sizeof(string_desc_arr) / sizeof(string_desc_arr[0])))
+      return NULL;
 
-    const char* str = string_desc_arr[index];
+    const char *str = string_desc_arr[index];
 
     // Cap at max char
     chr_count = TU_MIN(strlen(str), 31);
 
     // Convert ASCII string into UTF-16
-    for(uint8_t i=0; i<chr_count; i++)
+    for (uint8_t i = 0; i < chr_count; i++)
     {
-      _desc_str[1+i] = str[i];
+      _desc_str[1 + i] = str[i];
     }
   }
 
   // first byte is length (including header), second byte is string type
-  _desc_str[0] = (TUSB_DESC_STRING << 8 ) | (2*chr_count + 2);
+  _desc_str[0] = (TUSB_DESC_STRING << 8) | (2 * chr_count + 2);
 
   return _desc_str;
 }


### PR DESCRIPTION
I've added a USB Mass Storage device alongside the HID and CDC, which uses the on-board flash of the Pico. It's not very large (Windows reports 1.92MB once formatted), but it could be useful for storing a compressed OpenOCD archive (that's how I'm using it). By default, the drive presents itself as read-only and writing to it can be enabled by bridging GPIO14 to ground.  The mass storage device is enabled by default, but can be disabled from tusb_config.h .